### PR TITLE
Use HTTPS for jquery and links

### DIFF
--- a/quotes/templates/footer.html
+++ b/quotes/templates/footer.html
@@ -1,9 +1,9 @@
 <footer class="footer">
 <div class="container">
     <p>Créé par
-<a href="http://www.linkedin.com/pub/antoine-pietri/57/955/378">Antoine</a>
-et <a href="http://fr.linkedin.com/pub/paul-hervot/49/667/8a5/fr">Paul</a></p>
+<a href="https://www.linkedin.com/pub/antoine-pietri/57/955/378">Antoine</a>
+et <a href="https://fr.linkedin.com/pub/paul-hervot/49/667/8a5/fr">Paul</a></p>
 <p><a href="https://github.com/seirl/epiquote">Code</a> sous licence
-<a href="http://fr.wikipedia.org/wiki/Beerware" target="_blank">Beerware</a>
+<a href="https://fr.wikipedia.org/wiki/Beerware" target="_blank">Beerware</a>
 </div>
 </footer>

--- a/quotes/templates/start_body.html
+++ b/quotes/templates/start_body.html
@@ -1,5 +1,5 @@
 {% load staticfiles %}
-<script src="http://code.jquery.com/jquery-latest.js"></script>
+<script src="https://code.jquery.com/jquery-latest.js"></script>
 <script src="{% static "bootstrap/js/bootstrap.min.js" %}"></script>
 <script src="{% static "js/vote.js" %}"></script>
 <script src="{% static "js/fav.js" %}"></script>


### PR DESCRIPTION
- Change LinkedIn and Github links to `https://` to avoid unecessary redirections
- Fetch jquery with HTTPS to avoid mixed content browser warning