### PR TITLE
Update to the latest relase of django_registration

### DIFF
--- a/epiquote/forms.py
+++ b/epiquote/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth import get_user_model
-from registration.forms import RegistrationForm
+from django_registration.forms import RegistrationForm
 
 User = get_user_model()
 

--- a/epiquote/settings/common.py
+++ b/epiquote/settings/common.py
@@ -117,7 +117,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django_comments',
     'quotes',
-    'registration',
+    'django_registration',
     'bootstrapform',
 )
 

--- a/epiquote/urls.py
+++ b/epiquote/urls.py
@@ -1,6 +1,5 @@
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.contrib.auth import urls as auth_urls
 
 from epiquote import views
 

--- a/epiquote/urls.py
+++ b/epiquote/urls.py
@@ -1,11 +1,14 @@
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.auth import urls as auth_urls
+
 from epiquote import views
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^accounts/register/$', views.UserRegistrationView.as_view()),
-    url(r'^accounts/', include('registration.backends.hmac.urls')),
+    url(r'^accounts/', include('django_registration.backends.activation.urls')),
+    url(r'^accounts/', include('django.contrib.auth.urls')),
     url(r'^comments/', include('django_comments.urls')),
     url(r'^', include('quotes.urls')),
 ]

--- a/epiquote/views.py
+++ b/epiquote/views.py
@@ -1,5 +1,5 @@
 from epiquote.forms import UserRegistrationForm
-from registration.backends.hmac.views import RegistrationView
+from django_registration.backends.activation.views import RegistrationView
 
 
 class UserRegistrationView(RegistrationView):

--- a/quotes/templates/menu.html
+++ b/quotes/templates/menu.html
@@ -41,7 +41,7 @@
                 <a href="{% url 'login' %}">Connexion</a>
             </li>
             <li class="{% active '^/accounts/register' %}">
-                <a href="{% url 'registration_register' %}">Inscription</a>
+                <a href="{% url 'django_registration_register' %}">Inscription</a>
             </li>
           {% endif %}
         </ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django
--e 'git+https://github.com/ubernostrum/django-registration#egg=django-registration'
+django_registration
 django-bootstrap-form
 django-contrib-comments
 psycopg2-binary


### PR DESCRIPTION
This removes the git version of django_registration, allows users to use the pip release and includes some fixes (like the django views that aren't exposed anymore through django_registration).